### PR TITLE
Added ability to pass a logger into telegrafjs.

### DIFF
--- a/handlers/telegrafUdpHandler.js
+++ b/handlers/telegrafUdpHandler.js
@@ -23,7 +23,8 @@ module.exports = function (options) {
   return (messages) => {
     var udpClient = new telegraf.TelegrafUDPClient({
       host: options.host,
-      port: options.port
+      port: options.port,
+      logger: options.logger
     })
     return udpClient.connect()
       .then(function () {


### PR DESCRIPTION
Currently our production logs are being spammed with console.debug() lines from Telegrafjs:

![screen shot 2017-10-12 at 1 09 57 pm](https://user-images.githubusercontent.com/8171923/31516835-b75fea94-af4e-11e7-9742-bba633b58573.png)

Telegrafjs allows you to pass in a logger object. My plan is to pass in a logger that sets console.debug() to a noop function to prevent this log spamming.
